### PR TITLE
Simplify pagination normalization

### DIFF
--- a/.changeset/sixty-corners-flash.md
+++ b/.changeset/sixty-corners-flash.md
@@ -1,0 +1,5 @@
+---
+"@dugjason/front-node": patch
+---
+
+simplify pagination handling

--- a/src/base.ts
+++ b/src/base.ts
@@ -127,7 +127,7 @@ export class FrontBase {
       return undefined as TResult;
     }
     const parsed: unknown = JSON.parse(text);
-    return normalizeFrontResponse(parsed, this.baseUrl) as TResult;
+    return normalizeFrontResponse(parsed) as TResult;
   }
 
   /**

--- a/src/normalize-response.ts
+++ b/src/normalize-response.ts
@@ -22,43 +22,33 @@ export type PaginationInfo = Record<string, unknown> & {
  * If `next` is not a URL or has no `page_token`, returns `next` unchanged.
  *
  * @param next Value of `_pagination.next` from the raw API.
- * @param baseUrl API origin (used to resolve relative `next` links).
  */
-export const pageTokenFromPaginationNextUrl = (
-  next: string | null | undefined,
-  baseUrl: string,
-): string | null | undefined => {
-  if (next === undefined || next === null) {
-    return null;
-  }
-  if (next === "") {
+export const pageTokenFromPaginationNextUrl = (next?: string | null): string | null | undefined => {
+  if (!next) {
     return null;
   }
   try {
-    const u = new URL(next, baseUrl);
+    const u = new URL(next);
     const token = u.searchParams.get("page_token");
     if (token !== null && token !== "") {
       return token;
     }
   } catch {
     // not a URL
+    return null;
   }
-  return next;
+  return null;
 };
 
 /**
- * Walk JSON from the Front API: rename `_pagination` → `pagination` and replace `pagination.next`
- * full URLs with the `page_token` query value. Recurses into objects and arrays.
+ * Rename `_pagination` → `pagination` and replace `pagination.next` full URLs with the
+ * `page_token` query value.
  *
  * @param value Parsed JSON body.
- * @param baseUrl Same origin as the client (`FrontBase` / `Front` `baseUrl`).
  */
-export const normalizeFrontResponse = <T>(value: T, baseUrl: string): T => {
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => normalizeFrontResponse(item, baseUrl)) as T;
+export const normalizeFrontResponse = <T>(value: T): WithNormalizedPagination<T> => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value as WithNormalizedPagination<T>;
   }
   const input = value as Record<string, unknown>;
   const result: Record<string, unknown> = {};
@@ -68,13 +58,12 @@ export const normalizeFrontResponse = <T>(value: T, baseUrl: string): T => {
         const p = val as Record<string, unknown>;
         const nextRaw = p.next;
         const next =
-          typeof nextRaw === "string" ? pageTokenFromPaginationNextUrl(nextRaw, baseUrl) : nextRaw;
+          typeof nextRaw === "string" ? pageTokenFromPaginationNextUrl(nextRaw) : nextRaw;
         result.pagination = { ...p, next };
       }
       continue;
     }
-    result[key] =
-      val !== null && typeof val === "object" ? normalizeFrontResponse(val, baseUrl) : val;
+    result[key] = val;
   }
-  return result as T;
+  return result as WithNormalizedPagination<T>;
 };

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -20,7 +20,10 @@ export const createMockClient = (
   const requests: Request[] = [];
   const mockFetch = new Proxy(fetch, {
     apply: (_target, _thisArg, [input, init]: Parameters<typeof fetch>) => {
-      const req = input instanceof Request ? input : new Request(input, init);
+      const req =
+        input instanceof Request
+          ? input
+          : new Request(typeof input === "string" ? input : input.href, init);
       requests.push(req);
       return handler(req);
     },

--- a/tests/normalize-response.test.ts
+++ b/tests/normalize-response.test.ts
@@ -6,23 +6,21 @@ const base = "https://api2.frontapp.com";
 
 describe("pageTokenFromPaginationNextUrl", () => {
   test("extracts page_token from absolute next URL", () => {
-    expect(pageTokenFromPaginationNextUrl(`${base}/accounts?page_token=tok_1&limit=25`, base)).toBe(
-      "tok_1",
-    );
+    expect(
+      pageTokenFromPaginationNextUrl(
+        "https://api2.frontapp.com/accounts?page_token=tok_1&limit=25",
+      ),
+    ).toBe("tok_1");
   });
 
-  test("extracts page_token from relative next URL", () => {
-    expect(pageTokenFromPaginationNextUrl("/accounts?page_token=tok_rel", base)).toBe("tok_rel");
-  });
-
-  test("returns value unchanged when not a URL with page_token", () => {
-    expect(pageTokenFromPaginationNextUrl("opaque-token", base)).toBe("opaque-token");
+  test("returns null when not a URL", () => {
+    expect(pageTokenFromPaginationNextUrl("not a URL")).toBe(null);
   });
 
   test("handles null, undefined, and empty string", () => {
-    expect(pageTokenFromPaginationNextUrl(null, base)).toBe(null);
-    expect(pageTokenFromPaginationNextUrl(undefined, base)).toBe(null);
-    expect(pageTokenFromPaginationNextUrl("", base)).toBe(null);
+    expect(pageTokenFromPaginationNextUrl(null)).toBe(null);
+    expect(pageTokenFromPaginationNextUrl()).toBe(null);
+    expect(pageTokenFromPaginationNextUrl("")).toBe(null);
   });
 });
 
@@ -32,24 +30,13 @@ describe("normalizeFrontResponse", () => {
       _pagination: {
         next: `${base}/tags?page_token=xyz&limit=50`,
       },
-      _results: [{ id: "t1" }],
+      _results: [{ id: "tag_1" }],
     };
-    const n = normalizeFrontResponse(raw, base);
+    const n = normalizeFrontResponse(raw);
     expect(n).toEqual({
-      _results: [{ id: "t1" }],
+      _results: [{ id: "tag_1" }],
       pagination: { next: "xyz" },
     });
     expect(n).not.toHaveProperty("_pagination");
-  });
-
-  test("recurses into nested objects", () => {
-    const raw = {
-      outer: {
-        _pagination: { next: `${base}/inbox?page_token=nested` },
-        _results: [],
-      },
-    };
-    const n = normalizeFrontResponse(raw, base);
-    expect((n as { outer: { pagination: { next: string } } }).outer.pagination.next).toBe("nested");
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
+    "lib": ["ES2023"],
+    "types": ["bun", "node"],
     "strict": true,
     "declaration": true,
     "declarationMap": true,
@@ -17,6 +17,6 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Remove `baseUrl` from `pageTokenFromPaginationNextUrl` and `normalizeFrontResponse`; Front pagination `next` links are absolute URLs, so callers should not need to know the API origin.
- Limit normalization to top-level `_pagination` → `pagination` (no nested recursion) and return `WithNormalizedPagination<T>` for accurate typing.
- Include `tests/**/*` in `tsconfig.json` so test files are type-checked in CI.

## Test plan
- [x] `bun test tests/normalize-response.test.ts`
- [x] `bun run check`


Made with [Cursor](https://cursor.com)